### PR TITLE
Enable installation up/downgrades via role

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,55 @@ The system architecture (e.g. `386` or `amd64`) to use.
 
 The location where the Packer binary will be installed (should be in system `$PATH`).
 
+    packer_tmp_dir: "/tmp"
+
+The location where the packer archive will be unzipped to.
+
+    packer_force_version: yes
+
+Whether or not packer should update the target machine's `packer` symlink to the
+last installed binary.
+
+    packer_purge: no
+
+Whether to remove previous packer versions or not.
+
 ## Dependencies
 
 None.
 
 ## Example Playbook
 
+    # Install packer using role's defaults (1.0.0)
     - hosts: servers
+      roles:
+        - geerlingguy.packer
+
+    # Upgrade to a specific version, discarding any  files
+    # in `packer_bin_path` matching `packer_*`
+
+    - hosts: servers
+      vars:
+        packer_version: "1.5.1"
+      roles:
+        - geerlingguy.packer
+
+    # Downgrade the packer version but keep previous installation(s):
+
+    - hosts: servers
+      vars:
+        packer_version: "1.4.0"
+        packer_purge: no
+      roles:
+        - geerlingguy.packer
+
+    # Download an additional packer version, but do not
+    #  update the default (`{{ packer_bin_path }}/packer`)
+    # (implies `packer_purge=no`)
+    - hosts: servers
+      vars:
+        packer_version: "1.2.0"
+        packer_update_symlink: no
       roles:
         - geerlingguy.packer
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,6 @@
 packer_version: "1.0.0"
 packer_arch: "amd64"
 packer_bin_path: /usr/local/bin
+packer_tmp_dir: /tmp
+packer_update_symlink: yes
+packer_purge: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,40 @@
 - name: Ensure unzip is installed.
   package: name=unzip state=present
 
+- name: Remove previous Packer installation(s)
+  block:
+    - name: Find packer binaries in packer bin path
+      find:
+        path: "{{ packer_bin_path }}"
+        patterns: "packer_*"
+      register: found_binaries
+    - name: Remove binaries
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ found_binaries.files }}"
+  when: packer_purge and packer_update_symlink
+
 - name: Download and unarchive Packer.
   unarchive:
     src: https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ packer_arch }}.zip
-    dest: "{{ packer_bin_path }}"
+    dest: "{{ packer_tmp_dir }}"
+    creates: "{{ packer_bin_path }}/packer_{{ packer_version }}"
     remote_src: true
-    creates: "{{ packer_bin_path }}/packer"
+
+- name: Install binary
+  copy:
+    src: "{{ packer_tmp_dir }}/packer"
+    dest: "{{ packer_bin_path }}/packer_{{ packer_version }}"
+    remote_src: yes
+    mode: 0755
+
+- name: Create/Update Symlink
+  file:
+    state: link
+    dest: "{{ packer_bin_path }}/packer"
+    src: "{{ packer_bin_path }}/packer_{{ packer_version }}"
+    force: yes
+    mode: 0755
+  when: packer_update_symlink
+...


### PR DESCRIPTION
This breaks up the previous download/unpack/install
task into several sub-tasks, which enable a greater
granularity of installation options.

The following variables are introduced:

- packer_tmp_dir [/tmp]
- packer_update_symlink [yes]
- packer_purge [yes]

These enable the following features:

1. Upgrade/downgrade existing installation of packer

  Previously, this was not possible due to the binary
  being unzipped, moved and asserted to exist in a single
  task (`unarchive`).
  This commit introcudes separate download/unzip and installation
  steps. The latter copies the binary with a `version` suffix,
  and creates a softlink to it named `packer` at `packer_bin_path`.

2. Remove previous installations of the packer binary

  Setting `packer_purge: yes` will remove all files
  in `packer_bin_path` matching the pattern `packer_*`.
  This is enabled by default; if you need to maintain
  several version of packer, setting this to `no` will
  not touch existing packer binaries.

Note: the binary at `packer_tmp_dir` will be overwritten
**regardless** of `packer_version`.