### PR TITLE
Updated default packer version and override download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    packer_version: "1.0.0"
+    packer_version: "1.8.6"
 
 The Packer version to install.
 
@@ -23,6 +23,11 @@ The system architecture (e.g. `386` or `amd64`) to use.
     packer_bin_path: /usr/local/bin
 
 The location where the Packer binary will be installed (should be in system `$PATH`).
+
+    packer_repo_path: https://releases.hashicorp.com/
+
+The URL repository  where the Packer release can be downloaded from.
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
-packer_version: "1.0.0"
+packer_version: "1.8.6"
 packer_arch: "amd64"
 packer_bin_path: /usr/local/bin
+packer_repo_path: "https://releases.hashicorp.com"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Download and unarchive Packer.
   unarchive:
-    src: https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ packer_arch }}.zip
+    src: "{{ packer_repo_path }}/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ packer_arch }}.zip"
     dest: "{{ packer_bin_path }}"
     remote_src: true
     creates: "{{ packer_bin_path }}/packer"


### PR DESCRIPTION
Updated default packer version to latest version (1.8.6) and added the ability to override which server you can download the packer release zip file from for those of us on air gapped networks